### PR TITLE
Refactor O11S guide for clarity and structure

### DIFF
--- a/docs/savage/omega/alphascape/O11S.md
+++ b/docs/savage/omega/alphascape/O11S.md
@@ -194,7 +194,3 @@ Long Needle Kyrios will appear in the middle. Resolve the same way as earlier by
 Charybdis will bring all players down to single digits of HP. Prioritise healing tanks first and then the rest of the party. This is because following this, Mustard Bomb will go off on the MT and a Blaster Tether will need to be intercepted by the OT. 3 Atomic Rays will go off, so ensure that the whole party is healed by then.
 
 Loop is the hard enrage of the fight and the boss must be killed before the party is wiped.
-
-```
-
-```

--- a/docs/savage/omega/alphascape/O11S.md
+++ b/docs/savage/omega/alphascape/O11S.md
@@ -9,53 +9,67 @@ sidebar_custom_props:
 
 ![O11S](/savage/omega/o11s-banner.webp)
 
-Written by Ceo-of Bunnings@Adamantoise
+> **Written by:**  
+> Ceo-of Bunnings@Adamantoise
 
-# Summary
+## Summary
 
-## Raidplans:
+### Raidplans:
 
-Peripheral Synthesis 1: [https://raidplan.io/plan/kdqz7p3g9agek5ep/sKZVDSVMUwj3dParlcpJsA6aL7Y19xqx](https://raidplan.io/plan/kdqz7p3g9agek5ep/sKZVDSVMUwj3dParlcpJsA6aL7Y19xqx)
+- **Start + Peripheral Synthesis 1:** [View Plan](https://raidplan.io/plan/kdqz7p3g9agek5ep)
 
-Level Checker Phase (Program Loop): [https://raidplan.io/plan/28kb494bk3j5syrd/sQiGoPpMZlvrkgcd464aMICVoi77ttcz](https://raidplan.io/plan/28kb494bk3j5syrd/sQiGoPpMZlvrkgcd464aMICVoi77ttcz)
+- **Level Checker Phase (Program Loop) + Other:** [View Plan](https://raidplan.io/plan/28kb494bk3j5syrd)
 
-Peripheral Synthesis 2:
+- **Peripheral Synthesis 2 + Pantokrator 1 + Peripheral Synthesis 3:** [View Plan](https://raidplan.io/plan/bqwtwdkbpg4cqvkh)
 
-[https://raidplan.io/plan/bqwtwdkbpg4cqvkh/cMYkCp9Ty7hL7K4gKVRgWpHHbW2xoTjS](https://raidplan.io/plan/bqwtwdkbpg4cqvkh/cMYkCp9Ty7hL7K4gKVRgWpHHbW2xoTjS)
+- **Pantokrator 2:** [View Plan](https://raidplan.io/plan/045DConMIaqyHVVG)
 
-Pantokrator(A): [https://raidplan.io/plan/hqu9gsc4xegehc6s/4zbZ5nnoF9ELg9KWpxyLhiNszdrwdDOQ](https://raidplan.io/plan/hqu9gsc4xegehc6s/4zbZ5nnoF9ELg9KWpxyLhiNszdrwdDOQ)
+### Arena Waymarks:
 
-Peripheral Synthesis 3:
+```json
+{
+  "Name": "O11S - XIVMine",
+  "MapID": 593,
+  "A": { "X": 89.0, "Y": 0.0, "Z": 81.0, "ID": 0, "Active": true },
+  "B": { "X": 119.0, "Y": 0.0, "Z": 89.0, "ID": 1, "Active": true },
+  "C": { "X": 111.0, "Y": 0.0, "Z": 119.0, "ID": 2, "Active": true },
+  "D": { "X": 81.0, "Y": 0.0, "Z": 111.0, "ID": 3, "Active": true },
+  "One": { "X": 81.0, "Y": 0.0, "Z": 89.0, "ID": 4, "Active": true },
+  "Two": { "X": 111.0, "Y": 0.0, "Z": 81.0, "ID": 5, "Active": true },
+  "Three": { "X": 119.0, "Y": 0.0, "Z": 111.0, "ID": 6, "Active": true },
+  "Four": { "X": 89.0, "Y": 0.0, "Z": 119.0, "ID": 7, "Active": true }
+}
+```
 
-Pantokrator(B):
+Waymarks are used for lining up the fists during Peripheral Synthesis 2.
 
-## Arena Waymarks:
+## Suggested Resources:
 
-`{"Name":"O11S - XIVMine","MapID":593,"A":{"X":89.0,"Y":0.0,"Z":81.0,"ID":0,"Active":true},"B":{"X":119.0,"Y":0.0,"Z":89.0,"ID":1,"Active":true},"C":{"X":111.0,"Y":0.0,"Z":119.0,"ID":2,"Active":true},"D":{"X":81.0,"Y":0.0,"Z":111.0,"ID":3,"Active":true},"One":{"X":81.0,"Y":0.0,"Z":89.0,"ID":4,"Active":true},"Two":{"X":111.0,"Y":0.0,"Z":81.0,"ID":5,"Active":true},"Three":{"X":119.0,"Y":0.0,"Z":111.0,"ID":6,"Active":true},"Four":{"X":89.0,"Y":0.0,"Z":119.0,"ID":7,"Active":true}}`
-Waymarks are used for big fists!
+<iframe width="560" height="315" src="https://www.youtube.com/embed/B46xSUUP7vE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-# Suggested Resources:
+:::warning
+Some of the strategies in this video may differ from what is presented in the guide and raidplan. It is recommended to clarify what strategies you are using with your team to avoid any confusion.
+:::
 
-Guide by mizzteq I think lol
-Maybe another guide somewhere
+## Detailed Guide:
 
-# Detailed Guide:
-
-## Repeat Mechanics:
+### Repeat Mechanics:
 
 **Atomic Ray**: High Damage Raidwide. Heal and shield as necessary.
+
 **Mustard Bomb**: Magical Tankbuster that inflicts bleeding. Healers should manage the tank affected by the bleed where necessary.
+
 **Starboard/Larboard Wave Cannon**:
 
 - Starboard: 200-degree cleave to the right side of the boss, with a 180-degree turn after.
 - Larboard: 200-degree cleave to the left side of the boss, with a 180-degree turn after.
   **Flamethrower**: Protean on player location, followed by another Protean on the snapshotted location. Ensure everyone is spread to avoid clipping.
 
-## Start:
+### Start:
 
 The fight starts off with the boss casting Atomic Ray, then Mustard Bomb, then Flamethrower and then into a Starboard/Larboard Wave Cannon. Deal with these as needed.
 
-## Peripheral Synthesis 1:
+### Peripheral Synthesis 1:
 
 The boss will summon 6 rocket punch ads on all DPS and Healers, 3 of them being blue and 3 being yellow. These fists will mark the area under their designated player with a circle AoE before the AoE goes off.
 
@@ -67,14 +81,15 @@ Split the group into pairs on each cardinal; Tanks North, H1/D3 West, H2/D4 East
 - Spawn 1 set with the correct set, and the other 2 sets with the same coloured fists. Have one person each from the two incorrect sets swap spots with each other as soon as possible. We had D1/D3/D4 as our ‘flexing’ players for this.
 
 Once the mechanic is resolved, the DPS can then pick up the puddle for a damage boost.
+:::tip
+If you don’t manage to bait the fists immediately in the first round, relax and stand on top of your partner again! You have multiple attempts to bait before they explode and deal raidwide damage.
+:::
 
-TIP: If you don’t manage to bait the fists immediately in the first round, relax and stand on top of your partner again! You have multiple attempts to bait before they explode and deal raidwide damage.
-
-## Program Loop:
+### Program Loop:
 
 Following another Mustard Bomb, Omega will become untargetable and death zones will spawn on the edge and the centre of the arena, instantly killing the player if they step inside. A Level Checker will spawn, which needs to be killed before the Force Quit Enrage cast ends.
 
-### Ferrofluid + Executable 1 + Towers
+#### Ferrofluid + Executable 1 + Towers
 
 Level Checker will use Executable 1, giving a 14 second Looper Debuff, and Ferrofluid, applying a positive or negative charge and a tether, connected to another player. 4 meteor towers will also spawn in two possible patterns around the arena.
 
@@ -82,7 +97,7 @@ To resolve, players will spread around the boss, Supports North DPS South, RMMR,
 
 Players with the same charge will need to stand towards the centre to get pushed into the outer meteor towers. Players with opposite charges will need to stand around the edge of the arena to get pulled into the inner meteor towers. If done correctly, all towers will be soaked by two players each, removing the looper debuffs from each player. If a tower is not soaked, huge raidwide damage will go out and a damage down debuff will be given to all players.
 
-### Executable 2 + Chain of Memory
+#### Executable 2 + Chain of Memory
 
 Level Checker will place a Chain of Memory debuff on the two furthest players from Level Checker that forms a large line AoE between them. Touching this AoE will confuse the player that hits the chain. This chain moves between the area of the two players and is also controlled by them. Level Checker will also give Looper debuffs on the 6 remaining players, with 3 different rebuff durations and spawn in meteor towers.
 
@@ -93,14 +108,14 @@ The rest of the party will stack on the North or South side of the Level Checker
 The chain and the first close tower will spawn. The two players with the shortest Looper debuff will soak this tower. Once this tower is soaked, the Chain of Memory players will move clockwise until they are standing in the outer towers. The centre players should also move to avoid the chain. The centre tower should then be soaked by the players with the next shortest Looper debuffs.
 
 Once the 2nd centre tower is soaked, the Chain of Memory players move clockwise to the next outer towers to soak those, and the final players with Looper debuffs should soak the 3rd set of towers.
-
-TIP: If you are in the centre area soaking towers and your debuff is less than 10 seconds, you are soaking the next tower.
-
+:::tip
+If you are in the centre area soaking towers and your debuff is less than 10 seconds, you are soaking the next tower.
+:::
 As the Chain of Memory players soak their final towers, a large point blank AoE will appear under the Level Checker. Simply move out, then back in to avoid the following donut AoE.
 
 The boss will cast Delta Attack, a huge raidwide. Heals + Tank LB3 are needed to survive the attack.
 
-## Ballistic missiles + Flamethrower:
+### Ballistic missiles + Flamethrower:
 
 All players are marked with circle AoEs and Omega will also cast Flamethrower.
 
@@ -110,13 +125,13 @@ Two Starboard/Larboard Wave Cannon attacks will go off which need to be dodged i
 
 Mustard Bomb will also go off after this sequence.
 
-### Blaster:
+#### Blaster:
 
 A tether will target a player, which needs to be taken by the OT and must then move away from the raid to soak in order to not hit the other players. If the OT is not at full HP when taking this attack, they will get a doom debuff, so healers must ensure that the OT is topped off. The OT will receive a hp and damage penalty.
 
 Atomic Ray will follow, where healers must pay extra attention to the OT due to the HP debuff.
 
-## Peripheral Synthesis 2:
+### Peripheral Synthesis 2:
 
 Four large fists will spawn around the edges of the arena, with each fist tethered to a tank, healer and 2 dps respectively. We will use the waymarks to line up the Rocket Punches such that they travel across the edges of the arena, providing a safe zone in the middle for the other players.
 
@@ -132,7 +147,7 @@ Flamethrower will go off but will now enflict a 10s burn debuff, so healers shou
 
 Starboard/Larboard Wave Cannon Surge will go off. It is the same as Starboard/Larboard, but followed up immediately by another of the same attack, so the party must run through as soon as the animation for the first attack goes off.
 
-## Pantokrator:
+### Pantokrator:
 
 The boss will cast 4 sets of circle AoEs under players alongside small raidwides. Players should stack on the south side of the bosses’ and move CCW once the first set of puddles are dropped, ensuring to only move to the edge of the puddle to control where the dropping locations are.
 
@@ -148,7 +163,7 @@ Players should then move to the North East corner of the arena to avoid the Long
 
 Blaster should be taken by the OT again, which is then followed by Atomic Ray. Healers once again should pay extra attention to the OT.
 
-## Peripheral Synthesis 3:
+### Peripheral Synthesis 3:
 
 8 red fists will spawn around the arena. When two of them hit each other, they will deal high raidwide damage. If more than two hit each other, the damage will be too high, wiping the party.
 
@@ -162,7 +177,7 @@ Another Mustard Bomb and Atomic Ray will follow.
 
 The enhanced Flamethrower will go off and then Starboard/Larboard Wave Cannon Surge. Deal with this the same way as before.
 
-## Pantokrator 2:
+### Pantokrator 2:
 
 Circle AoEs will appear just like the first Pantokrator but this time, cone AoEs will also rotate around the boss and a Guided Missile Kyrios will target the furthest player for 6 circle AoEs.
 
@@ -179,3 +194,7 @@ Long Needle Kyrios will appear in the middle. Resolve the same way as earlier by
 Charybdis will bring all players down to single digits of HP. Prioritise healing tanks first and then the rest of the party. This is because following this, Mustard Bomb will go off on the MT and a Blaster Tether will need to be intercepted by the OT. 3 Atomic Rays will go off, so ensure that the whole party is healed by then.
 
 Loop is the hard enrage of the fight and the boss must be killed before the party is wiped.
+
+```
+
+```


### PR DESCRIPTION
Enhance the clarity and structure of the O11S guide by removing redundant lines and updating raid plans and mechanics. This improves readability and usability for players.