### PR TITLE
Add templates for Eden raid encounters and categories

### DIFF
--- a/docs/savage/eden/_category_.json
+++ b/docs/savage/eden/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "Eden",
+    "position": 4,
+    "link": {
+      "type": "generated-index",
+      "slug": "/eden"
+    }
+  }

--- a/docs/savage/eden/eternity/E10S.md
+++ b/docs/savage/eden/eternity/E10S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 10
+slug: /e10s
+title: "E10S - Shadowkeeper"
+description: "E10S - Shadowkeeper page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/verse/e10s.webp'
+---
+
+<!-- ![E10S](/savage/eden/verse/e10s-banner.webp) -->

--- a/docs/savage/eden/eternity/E11S.md
+++ b/docs/savage/eden/eternity/E11S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 11
+slug: /e11s
+title: "E11S - Fatebreaker"
+description: "E11S - Fatebreaker page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/verse/e11s.webp'
+---
+
+<!-- ![E11S](/savage/eden/verse/e11s-banner.webp) -->

--- a/docs/savage/eden/eternity/E12S.md
+++ b/docs/savage/eden/eternity/E12S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 12
+slug: /e12s
+title: "E12S - Eden's Promise"
+description: "E12S - Eden's Promise page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/verse/e12s.webp'
+---
+
+<!-- ![E12S](/savage/eden/verse/e12s-banner.webp) -->

--- a/docs/savage/eden/eternity/E9S.md
+++ b/docs/savage/eden/eternity/E9S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 9
+slug: /e9s
+title: "E9S - Cloud of Darkness"
+description: "E9S - Cloud of Darkness page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/verse/e9s.webp'
+---
+
+<!-- ![E9S](/savage/eden/verse/e9s-banner.webp) -->

--- a/docs/savage/eden/eternity/_category_.json
+++ b/docs/savage/eden/eternity/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Eternity",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "slug": "/eden/eternity"
+  },
+  "customProps": {
+      "cardImage": "savage/eden/eternity/e9s-banner.webp"
+    }
+}

--- a/docs/savage/eden/promise/E5S.md
+++ b/docs/savage/eden/promise/E5S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 5
+slug: /e5s
+title: "E5S - Ramuh"
+description: "E5S - Ramuh page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/promise/e5s.webp'
+---
+
+<!-- ![E5S](/savage/eden/promise/e5s-banner.webp) -->

--- a/docs/savage/eden/promise/E6S.md
+++ b/docs/savage/eden/promise/E6S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 6
+slug: /e6s
+title: "E6S - Ifrit and Garuda"
+description: "E6S - Ifrit and Garuda page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/promise/e6s.webp'
+---
+
+<!-- ![E6S](/savage/eden/promise/e6s-banner.webp) -->

--- a/docs/savage/eden/promise/E7S.md
+++ b/docs/savage/eden/promise/E7S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 7
+slug: /e7s
+title: "E7S - The Idol of Darkness"
+description: "E7S - The Idol of Darkness page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/promise/e7s.webp'
+---
+
+<!-- ![E7S](/savage/eden/promise/e7s-banner.webp) -->

--- a/docs/savage/eden/promise/E8S.md
+++ b/docs/savage/eden/promise/E8S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 8
+slug: /e8s
+title: "E8S - Shiva"
+description: "E8S - Shiva page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/promise/e8s.webp'
+---
+
+<!-- ![E8S](/savage/eden/promise/e8s-banner.webp) -->

--- a/docs/savage/eden/promise/_category_.json
+++ b/docs/savage/eden/promise/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Promise",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "slug": "/eden/promise"
+  },
+  "customProps": {
+      "cardImage": "savage/eden/promise/e5s-banner.webp"
+    }
+}

--- a/docs/savage/eden/verse/E1S.md
+++ b/docs/savage/eden/verse/E1S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 1
+slug: /e1s
+title: "E1S - Eden Prime"
+description: "E1S - Eden Prime page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/gate/e1s.webp'
+---
+
+<!-- ![E1S](/savage/eden/gate/e1s-banner.webp) -->

--- a/docs/savage/eden/verse/E2S.md
+++ b/docs/savage/eden/verse/E2S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+slug: /e2s
+title: "E2S - Voidwalker"
+description: "E2S - Voidwalker page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/gate/e2s.webp'
+---
+
+<!-- ![E2S](/savage/eden/gate/e2s-banner.webp) -->

--- a/docs/savage/eden/verse/E3S.md
+++ b/docs/savage/eden/verse/E3S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 3
+slug: /e3s
+title: "E3S - Leviathan"
+description: "E3S - Leviathan page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/gate/e3s.webp'
+---
+
+<!-- ![E3S](/savage/eden/gate/e3s-banner.webp) -->

--- a/docs/savage/eden/verse/E4S.md
+++ b/docs/savage/eden/verse/E4S.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 4
+slug: /e4s
+title: "E4S - Titan"
+description: "E4S - Titan page."
+# sidebar_custom_props:
+#   cardImage: 'savage/eden/gate/e4s.webp'
+---
+
+<!-- ![E4S](/savage/eden/gate/e4s-banner.webp) -->

--- a/docs/savage/eden/verse/_category_.json
+++ b/docs/savage/eden/verse/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Verse",
+  "position": 1,
+  "link": {
+    "type": "generated-index",
+    "slug": "/eden/verse"
+  },
+  "customProps": {
+      "cardImage": "savage/eden/verse/e1s-banner.webp"
+    }
+}


### PR DESCRIPTION
Introduce templates for various Eden raid encounters and their respective categories, enhancing organization and accessibility of content.